### PR TITLE
raising HTTPError added to indicate missing credentials

### DIFF
--- a/pycouchdb/client.py
+++ b/pycouchdb/client.py
@@ -447,6 +447,8 @@ class Database(object):
         if wrapper is None:
             wrapper = lambda row: row
 
+        r.raise_for_status()
+
         for row in utils.as_json(r)["rows"]:
             yield wrapper(row)
 


### PR DESCRIPTION
Hi niwibe,

if you create a database object without providing proper credentials, querying fails with a rather non-descriptive

>  File "/usr/lib/python3.3/site-packages/pycouchdb/client.py", line 448, in _query
>    for row in utils.as_json(r)["rows"]:
> KeyError: 'rows'

This patch raises a HTTPError, if couchdb replies with a non 2XX status code.
Cheers,
tpltnt
