### PR TITLE
Replicate method

### DIFF
--- a/pycouchdb/client.py
+++ b/pycouchdb/client.py
@@ -132,10 +132,10 @@ class Server(object):
         :param source: URL to the source database
         :param target: URL to the target database
         """
-        params = copy.copy(kwargs)
-        data = {'source': source, 'target': target}
+        data = copy.copy(kwargs)
+        data.update({'source': source, 'target': target})
         data = utils.to_json(data).encode('utf-8')
-        return self.resource.post('_replicate', data=data, params=params)
+        return self.resource.post('_replicate', data=data)
 
 
 def _id_to_path(id):

--- a/tests.py
+++ b/tests.py
@@ -66,6 +66,14 @@ class ServerTests(unittest.TestCase):
         self.s.delete("testing1")
         self.s.delete("testing2")
 
+    def test_replicate_create(self):
+        self.s.create('testing1')
+        self.assertNotIn("testing2", self.s)
+        self.s.replicate("testing1", "testing2", create_target=True)
+        self.assertIn("testing2", self.s)
+        self.s.delete("testing1")
+        self.s.delete("testing2")
+
 
 class DatabaseTests(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
I've managed somehow to build a replicate method to the Server object - refs #4.
It's been only tested with the "create_target" optional argument, but it should work for the other fields.

see: https://wiki.apache.org/couchdb/Replication
