### PR TITLE
speed up JSON decoding by eliminating accidental calls to chardet

### DIFF
--- a/pycouchdb/utils.py
+++ b/pycouchdb/utils.py
@@ -99,11 +99,11 @@ def urljoin(base, *path):
 
 def as_json(response):
     if "application/json" in response.headers['content-type']:
-        response.encoding = 'utf-8'
-        if response.text != "":
-            return response.json()
+        response_src = response.content.decode('utf-8')
+        if response.content != b'':
+            return json.loads(response_src)
         else:
-            return response.text
+            return response_src
     return None
 
 


### PR DESCRIPTION
The `utils.as_json` method in pycouchdb is extremely slow because it uses `response.text`, which causes the requests module to call chardet, which is a complete waste of time because CouchDB never returns anything except UTF-8. This commit uses `response.content` instead, which is much faster.

In an app which queries a medium-size result (~620 rows, `include_docs=true`), I saw page-load times decrease from 6.10 seconds to 0.2 seconds.
