### PR TITLE
added support for include_docs='false' param on client.py all()

### DIFF
--- a/pycouchdb/client.py
+++ b/pycouchdb/client.py
@@ -389,6 +389,16 @@ class Database(object):
             for row in result["rows"]:
                 yield wrapper(row['doc'])
 
+        def _iterate_no_docs():
+            for row in result["rows"]:
+                doc = {"id": row['id'], "rev": row['value']['rev']}
+                yield wrapper(doc)
+
+        if params["include_docs"].upper() == "FALSE":
+            if as_list:
+                return list(_iterate_no_docs())
+            return _iterate_no_docs()
+
         if as_list:
             return list(_iterate())
         return _iterate()


### PR DESCRIPTION
This is in regards to issue #38. Its not as elegant as handling all of the parameters in a single iterator but I'm not sure how to do that with the response you get from couchdb when ommiting documents. Its not a big deal to use requests manually and just query /_all_docs, since py-couchdb has it as a dependancy anyways, but this way the library will cover _all_docs in its entirety.
