### PR TITLE
FIX 39: pouchdb.utils.quote fails with unicode characters on Python 2.7....

### DIFF
--- a/pycouchdb/utils.py
+++ b/pycouchdb/utils.py
@@ -50,7 +50,7 @@ def _extract_credentials(url):
 
 
 def quote(data, safe=b''):
-    if isinstance(data, str):
+    if isinstance(data, string_type):
         data = data.encode('utf-8')
     return _quote(data, safe)
 

--- a/tests.py
+++ b/tests.py
@@ -484,5 +484,12 @@ class DatabaseAttachmentsTest(unittest.TestCase):
         self.assertIn("sample.txt", doc["_attachments"])
 
 
+class UtilsTest(unittest.TestCase):
+
+    def test_quote(self):
+        #
+        self.assertEqual(couchdb.utils.quote('Š'), '%C5%A0')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix #39 
