### PR TITLE
Remove the default value for `since`.

### DIFF
--- a/pycouchdb/client.py
+++ b/pycouchdb/client.py
@@ -34,8 +34,6 @@ def _listen_feed(object, node, feed_reader, **kwargs):
     # Possible options: "continuous", "longpoll"
     kwargs.setdefault("feed", "continuous")
 
-    kwargs.setdefault("since", 1)
-
     (resp, result) = object.resource(node).get(
         params=kwargs, stream=True)
     try:


### PR DESCRIPTION
- It should not be defaulted to `1`, because seq may be a string (like
  in Cloudant)