### PR TITLE
new feature: optionally use OrderedDict when parsing returned JSON to…

### DIFF
--- a/pycouchdb/client.py
+++ b/pycouchdb/client.py
@@ -95,13 +95,14 @@ class Server(object):
     """
 
     def __init__(self, base_url=DEFAULT_BASE_URL, full_commit=True,
-                 authmethod="basic", verify=False):
+                 authmethod="basic", verify=False, use_ordered_dict=False):
 
         self.base_url, credentials = utils.extract_credentials(base_url)
         self.resource = Resource(self.base_url, full_commit,
                                  credentials=credentials,
                                  authmethod=authmethod,
-                                 verify=verify)
+                                 verify=verify,
+                                 use_ordered_dict=use_ordered_dict)
 
     def __repr__(self):
         return '<CouchDB Server "{}">'.format(self.base_url)

--- a/pycouchdb/resource.py
+++ b/pycouchdb/resource.py
@@ -10,10 +10,11 @@ from . import exceptions
 
 class Resource(object):
     def __init__(self, base_url, full_commit=True, session=None,
-                 credentials=None, authmethod="session", verify=False):
+                 credentials=None, authmethod="session", verify=False, use_ordered_dict=False):
 
         self.base_url = base_url
 #        self.verify = verify
+        self.use_ordered_dict = use_ordered_dict
 
         if not session:
             self.session = requests.session()
@@ -49,7 +50,7 @@ class Resource(object):
 
     def __call__(self, *path):
         base_url = utils.urljoin(self.base_url, *path)
-        return self.__class__(base_url, session=self.session)
+        return self.__class__(base_url, session=self.session, use_ordered_dict=self.use_ordered_dict)
 
     def _check_result(self, response, result):
         try:
@@ -96,7 +97,7 @@ class Resource(object):
             result = None
             self._check_result(response, result)
         else:
-            result = utils.as_json(response)
+            result = utils.as_json(response, self.use_ordered_dict)
 
         if result is None:
             return response, result

--- a/pycouchdb/utils.py
+++ b/pycouchdb/utils.py
@@ -2,7 +2,7 @@
 
 import json
 import sys
-
+from collections import OrderedDict
 
 if sys.version_info[0] == 3:
     from urllib.parse import quote as _quote
@@ -97,11 +97,12 @@ def urljoin(base, *path):
     return ''.join(retval)
 
 
-def as_json(response):
+def as_json(response, use_ordered_dict=False):
     if "application/json" in response.headers['content-type']:
         response_src = response.content.decode('utf-8')
         if response.content != b'':
-            return json.loads(response_src)
+            hook = OrderedDict if use_ordered_dict else None
+            return json.loads(response_src, object_pairs_hook=hook)
         else:
             return response_src
     return None


### PR DESCRIPTION
… ensure that the order of the elements is the same as in the DB
You can use this feature by setting `use_ordered_dict=True` when creating a `pycouchdb.Server` object.