### PR TITLE
ID loop in save_bulk

### DIFF
--- a/pycouchdb/client.py
+++ b/pycouchdb/client.py
@@ -387,15 +387,16 @@ class Database(object):
 
         return _doc
 
-    def save_bulk(self, docs, try_setting_id=False, transaction=True):
+    def save_bulk(self, docs, try_setting_ids=True, transaction=True):
         """
         Save a bulk of documents.
 
         .. versionchanged:: 1.2
             Now returns a new document list instead of modify the original.
 
-        :param try_setting_id: if ``True``, we loop through docs and generate/set an id in each doc if none exists
         :param docs: list of docs
+        :param try_setting_ids: if ``True``, we loop through docs and generate/set
+                            an id in each doc if none exists
         :param transaction: if ``True``, couchdb do a insert in transaction
                             model.
         :returns: docs
@@ -403,8 +404,8 @@ class Database(object):
 
         _docs = copy.deepcopy(docs)
 
-        # Insert _id field if it not exists and try_setting_id is true
-        if try_setting_id:
+        # Insert _id field if it not exists and try_setting_ids is true
+        if try_setting_ids:
             for doc in _docs:
                 if "_id" not in doc:
                     doc["_id"] = uuid.uuid4().hex

--- a/pycouchdb/client.py
+++ b/pycouchdb/client.py
@@ -387,13 +387,14 @@ class Database(object):
 
         return _doc
 
-    def save_bulk(self, docs, transaction=True):
+    def save_bulk(self, docs, try_setting_id=False, transaction=True):
         """
         Save a bulk of documents.
 
         .. versionchanged:: 1.2
             Now returns a new document list instead of modify the original.
 
+        :param try_setting_id: if ``True``, we loop through docs and generate/set an id in each doc if none exists
         :param docs: list of docs
         :param transaction: if ``True``, couchdb do a insert in transaction
                             model.
@@ -402,10 +403,11 @@ class Database(object):
 
         _docs = copy.deepcopy(docs)
 
-        # Insert _id field if it not exists
-        for doc in _docs:
-            if "_id" not in doc:
-                doc["_id"] = uuid.uuid4().hex
+        # Insert _id field if it not exists and try_setting_id is true
+        if try_setting_id:
+            for doc in _docs:
+                if "_id" not in doc:
+                    doc["_id"] = uuid.uuid4().hex
 
         data = utils.force_bytes(json.dumps({"docs": _docs}))
         params = {"all_or_nothing": "true" if transaction else "false"}


### PR DESCRIPTION
In most cases the id's should already be set in given document list. If this is the case, the loop is useless and should not be started. For backwards compatiblity try_setting_ids is set to True by default.