### PR TITLE
Add __nonzero__ to Database, is DB available?

### DIFF
--- a/pycouchdb/client.py
+++ b/pycouchdb/client.py
@@ -265,6 +265,11 @@ class Database(object):
         (resp, result) = self.resource.get()
         return result
 
+    def __nonzero__(self):
+        """Is the database available"""
+        resp, _ = self.resource.head()
+        return resp.status_code == 200
+
     def __len__(self):
         return self.config()['doc_count']
 


### PR DESCRIPTION
Hi,

The Database class is missing __nonzero__ method. When calling bool on the object it fallbacks to __len__ which makes sense unless the database is empty. This IMHO is confusing as empty database is available and empty.
Adding __nonzero__ does not change the interface but extends it.
What do you think about this change?