### PR TITLE
Use POST for _changes (fixes #69)

### DIFF
--- a/pycouchdb/client.py
+++ b/pycouchdb/client.py
@@ -33,9 +33,10 @@ def _listen_feed(object, node, feed_reader, **kwargs):
 
     # Possible options: "continuous", "longpoll"
     kwargs.setdefault("feed", "continuous")
+    data = utils.force_bytes(json.dumps(kwargs.pop('data', {})))
 
-    (resp, result) = object.resource(node).get(
-        params=kwargs, stream=True)
+    (resp, result) = object.resource(node).post(
+        params=kwargs, data=data, stream=True)
     try:
         for line in resp.iter_lines():
             # ignore heartbeats

--- a/pycouchdb/resource.py
+++ b/pycouchdb/resource.py
@@ -93,7 +93,7 @@ class Resource(object):
         # Ignore result validation if
         # request is with stream mode
 
-        if stream:
+        if stream and response.status_code < 400:
             result = None
             self._check_result(response, result)
         else:


### PR DESCRIPTION
Use POST for changes and show errors when requesting a stream.  Fixes #69.