### PR TITLE
Customheaders auth

### DIFF
--- a/pycouchdb/client.py
+++ b/pycouchdb/client.py
@@ -84,8 +84,13 @@ class Server(object):
     :param full_commit: If ``False``, couchdb not commits all data on a
                         request is finished.
     :param authmethod: specify a authentication method. By default "basic"
-                       method is used but also exists "session" (that requires
-                       some server configuration changes).
+                       method is used. also exists "session" (that requires
+                       some server configuration changes). "customheader"
+                       exists as well for customized authentication methods
+    :param authheader: specify custom Authorization header to be used.
+                       It's very useful for JWT authentication method.
+                       This value should contain auth tipe like "Bearer "
+                       before the token itself.
 
     .. versionchanged: 1.4
        Set basic auth method as default instead of session method.
@@ -96,12 +101,13 @@ class Server(object):
     """
 
     def __init__(self, base_url=DEFAULT_BASE_URL, full_commit=True,
-                 authmethod="basic", verify=False):
+                 authmethod="basic", verify=False, authheader=""):
 
         self.base_url, credentials = utils.extract_credentials(base_url)
         self.resource = Resource(self.base_url, full_commit,
                                  credentials=credentials,
                                  authmethod=authmethod,
+                                 authheader=authheader,
                                  verify=verify)
 
     def __repr__(self):

--- a/pycouchdb/resource.py
+++ b/pycouchdb/resource.py
@@ -11,7 +11,7 @@ from . import exceptions
 
 class Resource(object):
     def __init__(self, base_url, full_commit=True, session=None,
-                 credentials=None, authmethod="session", verify=False):
+                 credentials=None, authmethod="session", authheader="", verify=False):
 
         self.base_url = base_url
 #        self.verify = verify
@@ -21,7 +21,7 @@ class Resource(object):
 
             self.session.headers.update({"accept": "application/json",
                                          "content-type": "application/json"})
-            self._authenticate(credentials, authmethod)
+            self._authenticate(credentials, authmethod, authheader)
 
             if not full_commit:
                 self.session.headers.update({'X-Couch-Full-Commit': 'false'})
@@ -29,7 +29,7 @@ class Resource(object):
             self.session = session
         self.session.verify = verify
 
-    def _authenticate(self, credentials, method):
+    def _authenticate(self, credentials, method, authheader):
         if not credentials:
             return
 
@@ -44,6 +44,9 @@ class Resource(object):
 
         elif method == "basic":
             self.session.auth = credentials
+
+        elif method == "customheader":
+            self.session.headers.update({'Authorization': authheader})
 
         else:
             raise RuntimeError("Invalid authentication method")

--- a/pycouchdb/resource.py
+++ b/pycouchdb/resource.py
@@ -30,7 +30,7 @@ class Resource(object):
         self.session.verify = verify
 
     def _authenticate(self, credentials, method, authheader):
-        if not credentials:
+        if not credentials and not authheader:
             return
 
         if method == "session":


### PR DESCRIPTION
Allow authenticate to couchDB Server using custom Authorization headers

Example:

```python
server = pycouchdb.Server(BASE_SERVER, authmethod="customheader", authheader="Bearer <redacted>")
```