### PR TITLE
fix: maintain session verify flag for new sub-resources

### DIFF
--- a/pycouchdb/resource.py
+++ b/pycouchdb/resource.py
@@ -25,9 +25,10 @@ class Resource(object):
 
             if not full_commit:
                 self.session.headers.update({'X-Couch-Full-Commit': 'false'})
+
+            self.session.verify = verify
         else:
             self.session = session
-        self.session.verify = verify
 
     def _authenticate(self, credentials, method):
         if not credentials:


### PR DESCRIPTION
The current behaviour on the creation of a sub-resource is that the `verify` flag is reset to `False`. The flag should be maintained for all the resources that share a session.

This can be shown in the following snippet:
```
import pycouchdb

server = pycouchdb.Server(..., verify=True)
assert server.resource.session.verify is True 

db = server.database("db_name")
assert db.resource.session.verify is True  # fails without this fix
assert server.resource.session.verify is True  # even worse: fails without this fix
```

